### PR TITLE
Update react-sortable library and implementation in PlaylistTrack component

### DIFF
--- a/client/components/PlaylistTrack.js
+++ b/client/components/PlaylistTrack.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Sortable } from 'react-sortable';
+import { sortable } from 'react-sortable';
 import formatDuration from '../utils/formatDuration';
 
 class Track extends React.Component {
@@ -50,6 +50,6 @@ Track.defaultProps = {
 };
 
 // eslint-disable-next-line
-const PlaylistTrack = Sortable(Track);
+const PlaylistTrack = sortable(Track);
 
 export default PlaylistTrack;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.1.0",
-    "react-sortable": "^1.1.0",
+    "react-sortable": "^1.2.0",
     "react-soundcloud-widget": "^2.0.4",
     "scssify": "^2.1.0",
     "sinon": "^1.17.6",


### PR DESCRIPTION
Update react-sortable library to version 1.2 and change function call from Sortable() to sortable() in PlaylistTrack component based on the library update.

See the following link for further explanation:
https://github.com/danielstocks/react-sortable/issues/57